### PR TITLE
Adding Pods configuration and fixing imported header

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -64,6 +64,8 @@
             <preference name="analytics_debug_write_key"/>
         </config-file>
 
+        <framework src="Analytics" type="podspec" spec="~> 3.0" />
+
         <header-file src="src/ios/AnalyticsPlugin.h" />
         <source-file src="src/ios/AnalyticsPlugin.m" />
     </platform>

--- a/src/ios/AnalyticsPlugin.m
+++ b/src/ios/AnalyticsPlugin.m
@@ -1,6 +1,6 @@
 #import "AnalyticsPlugin.h"
 #import <Cordova/CDV.h>
-#import <Analytics.h>
+#import <Analytics/SEGAnalytics.h>
 
 @implementation AnalyticsPlugin : CDVPlugin
 


### PR DESCRIPTION
Added the Analytics pod to the plugin.xml, so everything is installed when you add the plugin.
Fixed the imported header of the AnalyticsPlugin.m, according to the current documentation provided in [Segment](https://segment.com/docs/sources/mobile/ios/quickstart/)